### PR TITLE
Contig name fix

### DIFF
--- a/metasv/spades_contig.py
+++ b/metasv/spades_contig.py
@@ -1,5 +1,5 @@
 from svregion import *
-
+import re
 
 class SpadesContig:
     def __init__(self, name="", sequence=None):

--- a/metasv/spades_contig.py
+++ b/metasv/spades_contig.py
@@ -1,6 +1,6 @@
 from svregion import *
 import re
-
+pattern = re.compile(r'^(.+)_(\d+)_(\d+)_(INS|DEL)_\d+_NODE_\d+_length_(\d+)_cov_(\d*\.\d+|\d+)')
 class SpadesContig:
     def __init__(self, name="", sequence=None):
         if sequence is not None:
@@ -8,7 +8,7 @@ class SpadesContig:
         self.parse_name(name)
 
     def parse_name(self, name):
-        name_match = re.search(r'^(.+)_(\d+)_(\d+)_(INS|DEL)_\d+_NODE_\d+_length_(\d+)_cov_(\d+)',name)
+        name_match = pattern.search(name)
 
         self.sv_region = SVRegion(name_match.group(1), int(name_match.group(2)), name_match.group(1), int(name_match.group(3)))
         self.sv_type = name_match.group(4)

--- a/metasv/spades_contig.py
+++ b/metasv/spades_contig.py
@@ -8,13 +8,13 @@ class SpadesContig:
         self.parse_name(name)
 
     def parse_name(self, name):
-        name_fields = name.strip().split("_")
+        name_match = re.search(r'^(.+)_(\d+)_(\d+)_(INS|DEL)_\d+_NODE_\d+_length_(\d+)_cov_(\d+)',name)
 
-        self.sv_region = SVRegion(name_fields[0], int(name_fields[1]), name_fields[0], int(name_fields[2]))
-        self.sv_type = name_fields[3]
+        self.sv_region = SVRegion(name_match.group(1), int(name_match.group(2)), name_match.group(1), int(name_match.group(3)))
+        self.sv_type = name_match.group(4)
         self.sv_len = 0
-        self.sequence_len = int(name_fields[8])
-        self.covs = float(name_fields[10])
+        self.sequence_len = int( name_match.group(5))
+        self.covs = float(name_match.group(6))
 
         self.raw_name = name.strip()
 


### PR DESCRIPTION
our genomes very often have '_' character in the contig name, e.g.
Bd1
Bd2
Bd3
scaffold_1513

splitting the name fields on _ therefor breaks.   patch is one way of allowing _ in the contig name, anchoring parsing to more specifically match the spade names.  

probably better anchored to the right in case spade produced contigs are run through metasv, but the INS|DEL is extra specific 

