### PR TITLE
Provide SOURCES for reassembled outputs

### DIFF
--- a/metasv/sv_interval.py
+++ b/metasv/sv_interval.py
@@ -195,6 +195,7 @@ class SVInterval:
                 # TODO: kind of strange
                 if interval.info:
                     temp_info.update(interval.info)
+        temp_info.update({"SOURCES": str(self)})
         return temp_info
 
     def _get_svmethods(self):
@@ -228,7 +229,6 @@ class SVInterval:
         info.update({"VT": "SV"})
         info.update({"SVTOOL": "MetaSVMerge"})
         info.update({"NUM_SVMETHODS": len(self.sources)})
-        info.update({"SOURCES": str(self)})
         if self.cipos:
             info.update({"CIPOS": (",".join([str(a) for a in self.cipos]))})
 


### PR DESCRIPTION
Marghoob -- this is a small PR to help with debugging assembly outputs by including the original sources. Let me know if you prefer small PRs like this or to collect them up into larger chunks for evaluation. Happy to do whatever is easiest for you. Thanks much.

Knowing the input source of calls is useful for debugging and this was
present in the `pre_asm.vcf` file but not when reassembly gets run.
This moves the creation of this INFO key to a global location shared
by both VCF and BED (as input to assembly) files.