### PR TITLE
Remove filtered VCF variants for Lumpy, Manta, CNVkit and WHAM

### DIFF
--- a/metasv/vcf_utils.py
+++ b/metasv/vcf_utils.py
@@ -6,6 +6,9 @@ from sv_interval import *
 from defaults import SVS_SUPPORTED, MAX_SV_LENGTH
 import pysam
 
+# Callers to remove filtered values when reading
+REMOVE_FILTERED = set(["BreakSeq", "Lumpy", "Manta", "CNVkit", "WHAM"])
+
 
 def print_header(header, file_fd):
     for line in header:
@@ -110,7 +113,7 @@ def load_intervals(in_vcf, intervals={}, gap_intervals=[], include_intervals=[],
                                       gt=gt)
 
         else:
-            if source == "BreakSeq" and "PASS" not in vcf_record.FILTER: continue
+            if source in REMOVE_FILTERED and vcf_record.FILTER and "PASS" not in vcf_record.FILTER: continue
 
             if len(vcf_record.ALT) > 1: continue
             if "SVTYPE" not in vcf_record.INFO or "END" not in vcf_record.INFO:


### PR DESCRIPTION
Marghoob;
Following up on #63, I managed to improve precision quite a bit after realizing that filtered variants were being included as MetaSV inputs for all of the new callers. This fix avoids that, and greatly improves our precision:

![precise deletions](http://i.imgur.com/CIzUz7f.png)

Nice, I'll continue to tweak but this brings us more in line with expectations. Thanks again for all the merges and discussion.