### PR TITLE
Fix merging intervals

### DIFF
--- a/metasv/main.py
+++ b/metasv/main.py
@@ -3,7 +3,7 @@ import shutil
 
 from defaults import *
 from vcf_utils import *
-from sv_interval import SVInterval, get_gaps_file, interval_overlaps_interval_list, merge_intervals
+from sv_interval import SVInterval, get_gaps_file, interval_overlaps_interval_list, merge_intervals, merge_intervals_recursively
 from pindel_reader import PindelReader
 from breakdancer_reader import BreakDancerReader
 from breakseq_reader import BreakSeqReader
@@ -209,21 +209,7 @@ def run_metasv(args):
 
         # Do the inter-tool merging
         logger.info("Inter-tool Merging SVs of type %s" % sv_type)
-        merged_intervals = merge_intervals(tool_merged_intervals[sv_type])
-
-        # Intervals which overlap well with merged_intervals
-        intervals1 = []
-        # Intervals which do not overlap well with merged_intervals.
-        # Used to filter out small intervals which got merged with large intervals
-        intervals2 = []
-
-        logger.info("Checking overlaps SVs of type %s" % sv_type)
-        for interval in tool_merged_intervals[sv_type]:
-            if interval_overlaps_interval_list(interval, merged_intervals, args.overlap_ratio, args.overlap_ratio):
-                intervals2.append(interval)
-            else:
-                intervals1.append(interval)
-        final_intervals.extend(merge_intervals(intervals1) + merge_intervals(intervals2))
+        final_intervals.extend(merge_intervals_recursively(tool_merged_intervals[sv_type],args.overlap_ratio))
 
     final_chr_intervals = {contig.name: [] for contig in contigs}
     for interval in final_intervals:

--- a/metasv/run_spades.py
+++ b/metasv/run_spades.py
@@ -55,7 +55,7 @@ def run_spades_single(intervals=[], bam=None, spades=None, work=None, pad=SPADES
     merged_contigs = open(os.path.join(work, "merged.fa"), "w")
     spades_log_fd = open(os.path.join(work, "spades.log"), "w")
 
-    extract_fns = [extract_pairs.all_pair, extract_pairs.non_perfect]
+    extract_fns = [extract_pairs.all_pair_hq, extract_pairs.non_perfect_hq]
 
     try:
         for interval in intervals:

--- a/metasv/sv_interval.py
+++ b/metasv/sv_interval.py
@@ -349,3 +349,26 @@ def merge_intervals(interval_list):
     merged_intervals.append(current_merged_interval)
     merged_intervals.sort()
     return merged_intervals
+
+
+def merge_intervals_recursively(interval_list,overlap_ratio):
+    merged_intervals = merge_intervals(interval_list)
+
+    # Intervals which overlap well with merged_intervals
+    intervals1 = []
+    # Intervals which do not overlap well with merged_intervals.
+    # Used to filter out small intervals which got merged with large intervals
+    intervals2 = []
+    for interval in interval_list:
+        if interval_overlaps_interval_list(interval, merged_intervals, overlap_ratio,overlap_ratio ):
+            intervals2.append(interval)
+        else:
+            intervals1.append(interval)
+    if len(intervals1)==0:
+        return merged_intervals
+    if len(intervals2)==0:
+        intervals1.sort()
+        return intervals1
+    final_merged = merge_intervals_recursively(intervals1,overlap_ratio) + merge_intervals_recursively(intervals2,overlap_ratio)
+    final_merged.sort()
+    return final_merged


### PR DESCRIPTION
When merging intervals in the inter-tool merging step, not reciprocally overlapped intervals get merged. To fix that, I recursively identify such intervals and remove from the merged list and report separately.