### PR TITLE
SEQ-7243: Read standard AGE output.

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,7 +138,7 @@ onclick="trackOutboundLink('https://github.com/bioinform/metasv/releases'); retu
    In addition, paths to the following tools must be provided as MetaSV arguments:
    <ul>
       <li><a href="http://bioinf.spbau.ru/spades">SPAdes</a>: Used for assembly around the SV breakpoints</li>
-      <li><a href="https://github.com/abyzovlab/AGE">AGE</a>: Used for determining the SV breakpoints using assembled contigs. Please use AGE code from the following <a href="https://github.com/marghoob/AGE/archive/simple-parseable-output.zip">fork</a> of the main repository-the code was modified to make AGE output simpler to parse. This dependency on the fork will be fixed in the next release. Please compile AGE without <code>OpenMP</code> support using <code>make OMP=no</code>.</li>
+      <li><a href="https://github.com/abyzovlab/AGE">AGE</a>: Used for determining the SV breakpoints using assembled contigs. Please compile AGE without <code>OpenMP</code> support using <code>make OMP=no</code>.</li>
    </ul>
 </p>
 

--- a/metasv/age_parser.py
+++ b/metasv/age_parser.py
@@ -119,11 +119,11 @@ class AgeRecord:
             start_end.append([int(m.group(1)), int(m.group(2))])
         return start_end
 
-    def parse_input_descriptor(self, line, line_num):
+    def parse_input_descriptor(self, age_fd):
         """Returns a tuple of filename and sequence length."""
-        m = self.rx_input.search(line)
+        m = self.rx_input.search(age_fd.line)
         if m is None:
-            raise AgeFormatError("INPUT DESCRIPTOR", line_num)
+            raise AgeFormatError("INPUT DESCRIPTOR", age_fd.line_num)
         return (m.group(2), int(m.group(1)))
 
     def read_excluded_range(self, age_fd, name, context):
@@ -176,14 +176,14 @@ class AgeRecord:
                     continue
 
                 if line.startswith("First  seq"):
-                    file1, len1 = self.parse_input_descriptor(line, age_fd.line_num)
+                    file1, len1 = self.parse_input_descriptor(age_fd)
                     if self.tr_region_1:
                         len1+=self.tr_region_1[1]                        
                     self.inputs.append(AgeInput(file1, len1))
                     continue
 
                 if line.startswith("Second seq"):
-                    file2, len2 = self.parse_input_descriptor(line, age_fd.line_num)
+                    file2, len2 = self.parse_input_descriptor(age_fd)
                     self.inputs.append(AgeInput(file2, len2))
                     continue
 

--- a/metasv/age_parser.py
+++ b/metasv/age_parser.py
@@ -226,7 +226,8 @@ class AgeRecord:
                     continue
 
                 #TODO: May need to fix ALTERNATIVE REGION for truncated regions
-                if line == self.SEC_ALTERNATIVE:
+                if line.startswith(self.SEC_ALTERNATIVE):
+                    self.n_alt = int(line.split()[-1])
                     self.alternate_regions = self.read_excluded_regions(age_fd, line)
                     continue
 
@@ -336,5 +337,5 @@ if __name__ == "__main__":
         print "Alignment intervals S1: ", rec.start1_end1s
         print "Alignment intervals S2: ", rec.start2_end2s
         print "Excised lengths and intervals: ", rec.excised_regions
-        print "Alternate regions: ", rec.alternate_regions
+        print "Number of alternate regions: ", rec.n_alt
         print "Homology length: ", rec.hom

--- a/metasv/age_parser.py
+++ b/metasv/age_parser.py
@@ -109,11 +109,11 @@ class AgeRecord:
             start_end.append([int(m.group(1)), int(m.group(2))])
         return start_end
 
-    def parse_input_descriptor(self, line):
+    def parse_input_descriptor(self, line, line_num):
         """Returns a tuple of filename and sequence length."""
         m = self.rx_input.search(line)
         if m is None:
-            raise AgeFormatError("INPUT DESCRIPTOR", age_fd.line_num)
+            raise AgeFormatError("INPUT DESCRIPTOR", line_num)
         return (m.group(2), int(m.group(1)))
 
     def read_excluded_range(self, age_fd, name, context):
@@ -163,14 +163,14 @@ class AgeRecord:
                     continue
 
                 if line.startswith("First  seq"):
-                    file1, len1 = self.parse_input_descriptor(line)
+                    file1, len1 = self.parse_input_descriptor(line, age_fd.line_num)
                     if self.tr_region_1:
                         len1+=self.tr_region_1[1]                        
                     self.inputs.append(AgeInput(file1, len1))
                     continue
 
                 if line.startswith("Second seq"):
-                    file2, len2 = self.parse_input_descriptor(line)
+                    file2, len2 = self.parse_input_descriptor(line, age_fd.line_num)
                     self.inputs.append(AgeInput(file2, len2))
                     continue
 

--- a/metasv/age_parser.py
+++ b/metasv/age_parser.py
@@ -310,3 +310,18 @@ class AgeRecord:
 
     def __repr__(self):
         return str(self)
+
+if __name__ == "__main__":
+    import sys
+    if len(sys.argv) != 2:
+        print "Bad number of arguments: Provide name of one AGE output file as test case for AGE parser."
+    else:
+        rec = AgeRecord(sys.argv[1])
+        print "Input descriptor: ", rec.inputs
+        print "Percent matches in alignment: ", rec.percent
+        print "Matches by flank: ", rec.percents
+        print "Alignment intervals S1: ", rec.start1_end1s
+        print "Alignment intervals S2: ", rec.start2_end2s
+        print "Excised lengths and intervals: ", rec.excised_regions
+        print "Alternate regions: ", rec.alternate_regions
+        print "Homology length: ", rec.hom


### PR DESCRIPTION
These changes to `age_parser.py` allow us to read AGE outputs in the format used by the main developer's branch, so MetaSV will not be decoupled from future improvements to AGE. Correspondingly, I removed the instructions to download AGE from the `simple-parseable-output` branch.

@marghoob, @johnmu, and Mohammad, I placed comments labeled `ATTN` in a few different places where AGE output even by the `simple-parseable-output` branch is more detailed than what MetaSV uses, or similarly, where both AGE branches provide information on multiple segments or boundaries although MetaSV only inspects the first of each. So I thought those sections may be especially critical for you to look at when reviewing this PR.
