### PR TITLE
SEQ-7330: Fix broken dependencies.

### DIFF
--- a/metasv/external_cmd.py
+++ b/metasv/external_cmd.py
@@ -1,0 +1,73 @@
+import time
+import shlex
+import subprocess
+from threading import Timer
+import unittest
+import logging
+
+class TimedExternalCmd:
+    def __init__(self, cmd, logger):
+        self.cmd = shlex.split(cmd)
+        self.p = None
+        self.did_timeout = False
+        self.logger = logger
+    def enforce_timeout(self):
+        self.p.terminate()
+        self.did_timeout = True
+    def run(self, cmd_log_fd_out=None, cmd_log_fd_err=None, timeout=None):
+        self.logger.info("Running %s with arguments %s" % (self.cmd[0].upper(), str(self.cmd[1::])))
+        cmd_log_fd_err = cmd_log_fd_err or cmd_log_fd_out
+        self.p = subprocess.Popen(self.cmd, stderr=cmd_log_fd_err, stdout=cmd_log_fd_out)
+        start_time = time.time()
+        if timeout:
+            t = Timer(timeout, self.enforce_timeout)
+            t.start()
+        self.p.wait()
+        if timeout:
+            t.cancel()
+            if self.did_timeout:
+                self.logger.error("Timed out after %d seconds", timeout)
+                return None
+        retcode = self.p.returncode
+        self.logger.info("Returned code %d (%g seconds)" % (retcode, time.time() - start_time))
+        return retcode
+
+
+class TestTimedExternalCmd(unittest.TestCase):
+    def test_run_complete(self):
+        cmd = TimedExternalCmd("sleep 1", self.logger)
+        self.assertEqual(cmd.run(timeout = 2), 0)
+        self.assertFalse(cmd.did_timeout)
+        return
+
+    def test_run_timeout(self):
+        start_tick = time.time()
+        cmd = TimedExternalCmd("sleep 2", self.logger)
+        cmd.run(timeout = 1)
+        run_time = time.time() - start_tick
+        self.assertTrue(cmd.did_timeout)
+        self.assertAlmostEqual(run_time, 1, delta=0.2)
+        return
+
+    def test_run_no_timeout(self):
+        cmd = TimedExternalCmd("sleep 1", self.logger)
+        retcode = cmd.run()
+        self.assertEqual(cmd.run(), 0)
+        self.assertFalse(cmd.did_timeout)
+        return
+
+    def test_run_fail(self):
+        cmd = TimedExternalCmd("sleep 1 2 3", self.logger)
+        retcode = cmd.run(timeout = 1)
+        self.assertIsNotNone(retcode)
+        self.assertIsNot(retcode, 0)
+        return
+
+    logger = None
+
+
+if __name__ == '__main__':
+    FORMAT = '%(levelname)s %(asctime)-15s %(name)-20s %(message)s'
+    logging.basicConfig(level=logging.INFO, format=FORMAT)
+    TestTimedExternalCmd.logger = logging.getLogger(__name__)
+    unittest.main()

--- a/metasv/run_spades.py
+++ b/metasv/run_spades.py
@@ -59,7 +59,7 @@ def run_spades_single(intervals=[], bam=None, spades=None, work=None, pad=SPADES
 
     try:
         for interval in intervals:
-            region = "%s:%d-%d" % (interval.chrom, interval.start, interval.end)
+            region = "%s:%d-%d" % (str(interval.chrom), interval.start, interval.end)
             thread_logger.info("Processing interval %s" % (str(interval).strip()))
 
             sv_type = interval.name.split(",")[1]


### PR DESCRIPTION
This fix addresses two recent issues that are introduced by external dependencies:
- When MetaSV is run with a more recent version of pybedtools (>= 0.7.0), SAMtools fails with a `TypeError` "Expected bytes, got unicode". This is because pybedtools returns unicode strings that promote certain strings in MetaSV, one of which is then passed to SAMtools.
- Execution of SPAdes and AGE is broken on Mac OS X (return value is 127) because `timeout` is not available on that platform.

This PR includes:
- A fix for the unicode bug. The unicode string is converted to a byte string.
- A new class `TimedExternalCmd` which is used for executing SPAdes and AGE under a timeout, but without platform-specific dependencies, so that it works both on Linux and Mac OS X.
- Various unit tests for `TimedExternalCmd`.

I validated this PR (a) in conjunction with #85 and AGE from abyzov/age/master, and (b) as-is but with AGE from marghoob/age/simple-parseable-output. The test case is that from #85.